### PR TITLE
Add user entity and repository

### DIFF
--- a/ApiService.Application/IUserRepository.cs
+++ b/ApiService.Application/IUserRepository.cs
@@ -1,0 +1,16 @@
+using ApiService.Domain;
+
+namespace ApiService.Application;
+
+public interface IUserRepository
+{
+    Task<User> CreateAsync(User user);
+    Task<User?> GetByIdAsync(Guid id);
+    Task<User?> GetByEmailAsync(string email);
+    Task<IEnumerable<User>> GetAllAsync();
+    Task UpdateAsync(User user);
+    Task DeleteAsync(Guid id);
+    Task UpdateEmailVerificationTokenAsync(Guid userId, string token);
+    Task UpdateRefreshTokenAsync(Guid userId, string refreshToken, DateTime expiry);
+    Task SetEmailVerifiedAsync(Guid userId);
+}

--- a/ApiService.Domain/User.cs
+++ b/ApiService.Domain/User.cs
@@ -1,0 +1,12 @@
+namespace ApiService.Domain;
+
+public class User
+{
+    public Guid Id { get; set; }
+    public string Email { get; set; } = string.Empty;
+    public string PasswordHash { get; set; } = string.Empty;
+    public bool IsEmailVerified { get; set; }
+    public string? EmailVerificationToken { get; set; }
+    public string? RefreshToken { get; set; }
+    public DateTime? RefreshTokenExpiry { get; set; }
+}

--- a/ApiService.Infrastructure/UserRepository.cs
+++ b/ApiService.Infrastructure/UserRepository.cs
@@ -1,0 +1,77 @@
+using ApiService.Application;
+using ApiService.Domain;
+
+namespace ApiService.Infrastructure;
+
+public class UserRepository : IUserRepository
+{
+    private readonly Dictionary<Guid, User> _users = new();
+
+    public Task<User> CreateAsync(User user)
+    {
+        _users[user.Id] = user;
+        return Task.FromResult(user);
+    }
+
+    public Task<User?> GetByIdAsync(Guid id)
+    {
+        _users.TryGetValue(id, out var user);
+        return Task.FromResult(user);
+    }
+
+    public Task<User?> GetByEmailAsync(string email)
+    {
+        var user = _users.Values.FirstOrDefault(u => u.Email == email);
+        return Task.FromResult(user);
+    }
+
+    public Task<IEnumerable<User>> GetAllAsync()
+    {
+        IEnumerable<User> users = _users.Values;
+        return Task.FromResult(users);
+    }
+
+    public Task UpdateAsync(User user)
+    {
+        if (_users.ContainsKey(user.Id))
+        {
+            _users[user.Id] = user;
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(Guid id)
+    {
+        _users.Remove(id);
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateEmailVerificationTokenAsync(Guid userId, string token)
+    {
+        if (_users.TryGetValue(userId, out var user))
+        {
+            user.EmailVerificationToken = token;
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateRefreshTokenAsync(Guid userId, string refreshToken, DateTime expiry)
+    {
+        if (_users.TryGetValue(userId, out var user))
+        {
+            user.RefreshToken = refreshToken;
+            user.RefreshTokenExpiry = expiry;
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task SetEmailVerifiedAsync(Guid userId)
+    {
+        if (_users.TryGetValue(userId, out var user))
+        {
+            user.IsEmailVerified = true;
+            user.EmailVerificationToken = null;
+        }
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- add User domain model
- introduce IUserRepository interface for user CRUD and token updates
- implement in-memory UserRepository

## Testing
- `dotnet build ApiService.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6cb006888326b4d14c406b6ff2fe