### PR TITLE
feat: add password reset flow

### DIFF
--- a/ApiService.Application/IAuthService.cs
+++ b/ApiService.Application/IAuthService.cs
@@ -8,6 +8,8 @@ public interface IAuthService
     Task<bool> ConfirmEmailAsync(Guid userId, string token);
     Task<AuthTokens?> LoginAsync(string email, string password);
     Task<AuthTokens?> RefreshTokenAsync(string refreshToken);
+    Task<bool> RequestPasswordResetAsync(string email);
+    Task<bool> ResetPasswordAsync(Guid userId, string token, string newPassword);
 }
 
 public record AuthTokens(string AccessToken, string RefreshToken);

--- a/ApiService.Application/IUserRepository.cs
+++ b/ApiService.Application/IUserRepository.cs
@@ -13,4 +13,6 @@ public interface IUserRepository
     Task UpdateEmailVerificationTokenAsync(Guid userId, string token);
     Task UpdateRefreshTokenAsync(Guid userId, string refreshToken, DateTime expiry);
     Task SetEmailVerifiedAsync(Guid userId);
+    Task UpdatePasswordResetTokenAsync(Guid userId, string token, DateTime expiry);
+    Task UpdatePasswordAsync(Guid userId, string passwordHash);
 }

--- a/ApiService.Domain/User.cs
+++ b/ApiService.Domain/User.cs
@@ -9,4 +9,6 @@ public class User
     public string? EmailVerificationToken { get; set; }
     public string? RefreshToken { get; set; }
     public DateTime? RefreshTokenExpiry { get; set; }
+    public string? PasswordResetToken { get; set; }
+    public DateTime? PasswordResetTokenExpiry { get; set; }
 }

--- a/ApiService.Infrastructure/UserRepository.cs
+++ b/ApiService.Infrastructure/UserRepository.cs
@@ -74,4 +74,25 @@ public class UserRepository : IUserRepository
         }
         return Task.CompletedTask;
     }
+
+    public Task UpdatePasswordResetTokenAsync(Guid userId, string token, DateTime expiry)
+    {
+        if (_users.TryGetValue(userId, out var user))
+        {
+            user.PasswordResetToken = token;
+            user.PasswordResetTokenExpiry = expiry;
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task UpdatePasswordAsync(Guid userId, string passwordHash)
+    {
+        if (_users.TryGetValue(userId, out var user))
+        {
+            user.PasswordHash = passwordHash;
+            user.PasswordResetToken = null;
+            user.PasswordResetTokenExpiry = null;
+        }
+        return Task.CompletedTask;
+    }
 }

--- a/ApiService.Web/Controllers/AuthController.cs
+++ b/ApiService.Web/Controllers/AuthController.cs
@@ -54,9 +54,35 @@ public class AuthController : ControllerBase
 
         return Ok("Email confirmed.");
     }
+
+    [HttpPost("request-password-reset")]
+    public async Task<IActionResult> RequestPasswordReset([FromBody] RequestPasswordResetRequest request)
+    {
+        var success = await _authService.RequestPasswordResetAsync(request.Email);
+        if (!success)
+        {
+            return BadRequest("Invalid email.");
+        }
+
+        return Ok("Password reset email sent.");
+    }
+
+    [HttpPost("reset-password")]
+    public async Task<IActionResult> ResetPassword([FromBody] ResetPasswordRequest request)
+    {
+        var success = await _authService.ResetPasswordAsync(request.UserId, request.Token, request.NewPassword);
+        if (!success)
+        {
+            return BadRequest("Invalid token.");
+        }
+
+        return Ok("Password reset successful.");
+    }
 }
 
 public record RegisterRequest(string Email, string Password);
 public record LoginRequest(string Email, string Password);
 public record RefreshTokenRequest(string RefreshToken);
+public record RequestPasswordResetRequest(string Email);
+public record ResetPasswordRequest(Guid UserId, string Token, string NewPassword);
 


### PR DESCRIPTION
## Summary
- implement password reset request and completion in AuthService and controller
- store password reset token and expiry in user repository and domain

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa725a03dc8326b39e64cb3ed7d204