### PR TITLE
Increase JWT key length to satisfy HMAC requirements

### DIFF
--- a/ApiService.Web/appsettings.json
+++ b/ApiService.Web/appsettings.json
@@ -7,9 +7,11 @@
   },
   "AllowedHosts": "*",
   "Jwt": {
-    "Key": "SuperSecretDevelopmentKey12345"
+    // Key must be at least 256 bits (32 characters) for HMAC SHA-256
+    "Key": "SuperSecretDevelopmentKey1234567890"
   },
   "ConnectionStrings": {
     "DefaultConnection": "Server=DESKTOP-HEMOIMD\\BACKENDSQLSERVE; Database=db_services_api; Trusted_Connection=True; Trust Server Certificate=True"
   }
 }
+


### PR DESCRIPTION
## Summary
- ensure default JWT signing key is at least 256 bits to avoid runtime exceptions

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8278c6ec832689f2611ae4fe72c4